### PR TITLE
Additional support for custom `options.slugger`

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,6 @@ export default function rehypeSlug(options = {}) {
 
     visit(tree, 'element', (node) => {
       if (headingRank(node) && node.properties && !hasProperty(node, 'id')) {
-        const hmm = toString(node)
-        console.log(`>>> > visit > hmm:`, hmm)
         node.properties.id = prefix + slugger.slug(toString(node))
       }
     })

--- a/index.js
+++ b/index.js
@@ -3,10 +3,35 @@
  */
 
 /**
+ * @typedef {Function} SlugFunction
+ *   Custom `slug` implementation (optional).
+ * @param  {string} value
+ *   String of text to 'slugify'
+ * @return {string}
+ *   A unique slug string
+ */
+
+/**
+ * @typedef {Function} ResetFunction
+ *   Custom `reset` implementation (optional).
+ */
+
+/**
+ * @typedef SluggerImplementation
+ *   Custom `Slugger` implementation (optional).
+ * @property {SlugFunction} slug
+ *   The function to call for `slug(string)`
+ * @property {ResetFunction} [reset]
+ *   The function to call for `reset()`
+ */
+
+/**
  * @typedef Options
  *   Configuration (optional).
  * @property {string} [prefix='']
  *   Prefix to add in front of `id`s.
+ * @property {SluggerImplementation} [slugger]
+ *  The `Slugger` implementation to use.
  */
 
 import Slugger from 'github-slugger'
@@ -24,13 +49,18 @@ const slugs = new Slugger()
  */
 export default function rehypeSlug(options = {}) {
   const prefix = options.prefix || ''
+  const slugger = options.slugger || slugs
 
   return (tree) => {
-    slugs.reset()
+    if (slugger.reset) {
+      slugger.reset()
+    }
 
     visit(tree, 'element', (node) => {
       if (headingRank(node) && node.properties && !hasProperty(node, 'id')) {
-        node.properties.id = prefix + slugs.slug(toString(node))
+        const hmm = toString(node)
+        console.log(`>>> > visit > hmm:`, hmm)
+        node.properties.id = prefix + slugger.slug(toString(node))
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rehype-slug",
+  "name": "rehype-slugify",
   "version": "5.1.0",
   "description": "rehype plugin to add `id` attributes to headings",
   "license": "MIT",
@@ -48,6 +48,7 @@
     "remark-cli": "^11.0.0",
     "remark-preset-wooorm": "^9.0.0",
     "rimraf": "^3.0.0",
+    "slugify": "^1.6.5",
     "tape": "^5.0.0",
     "type-coverage": "^2.0.0",
     "typescript": "^4.0.0",

--- a/test.js
+++ b/test.js
@@ -1,9 +1,10 @@
 import test from 'tape'
+import slugify from 'slugify'
 import {rehype} from 'rehype'
 import rehypeSlug from './index.js'
 
 test('rehypeSlug', (t) => {
-  t.plan(4)
+  t.plan(10)
 
   rehype()
     .data('settings', {fragment: true})
@@ -15,7 +16,8 @@ test('rehypeSlug', (t) => {
         '  <h2>dolor—sit—amet</h2>',
         '  <h3>consectetur &amp; adipisicing</h3>',
         '  <h4>elit</h4>',
-        '  <h5>elit</h5>',
+        '  <h5>Elit</h5>',
+        '  <h5>Elit </h5>',
         '  <p>sed</p>',
         '</section>'
       ].join('\n'),
@@ -30,7 +32,8 @@ test('rehypeSlug', (t) => {
             '  <h2 id="dolorsitamet">dolor—sit—amet</h2>',
             '  <h3 id="consectetur--adipisicing">consectetur &#x26; adipisicing</h3>',
             '  <h4 id="elit">elit</h4>',
-            '  <h5 id="elit-1">elit</h5>',
+            '  <h5 id="elit-1">Elit</h5>',
+            '  <h5 id="elit-">Elit </h5>',
             '  <p>sed</p>',
             '</section>'
           ].join('\n'),
@@ -41,7 +44,7 @@ test('rehypeSlug', (t) => {
 
   rehype()
     .data('settings', {fragment: true})
-    .use(rehypeSlug, {prefix: 'test-'})
+    .use(rehypeSlug, {prefix: 'prefix--'})
     .process(
       [
         '<section>',
@@ -49,7 +52,8 @@ test('rehypeSlug', (t) => {
         '  <h2>dolor—sit—amet</h2>',
         '  <h3>consectetur &amp; adipisicing</h3>',
         '  <h4>elit</h4>',
-        '  <h5>elit</h5>',
+        '  <h5>Elit</h5>',
+        '  <h5>Elit </h5>',
         '  <p>sed</p>',
         '</section>'
       ].join('\n'),
@@ -60,11 +64,134 @@ test('rehypeSlug', (t) => {
           String(file),
           [
             '<section>',
-            '  <h1 id="test-lorem-ipsum-">Lorem ipsum 😪</h1>',
-            '  <h2 id="test-dolorsitamet">dolor—sit—amet</h2>',
-            '  <h3 id="test-consectetur--adipisicing">consectetur &#x26; adipisicing</h3>',
-            '  <h4 id="test-elit">elit</h4>',
-            '  <h5 id="test-elit-1">elit</h5>',
+            '  <h1 id="prefix--lorem-ipsum-">Lorem ipsum 😪</h1>',
+            '  <h2 id="prefix--dolorsitamet">dolor—sit—amet</h2>',
+            '  <h3 id="prefix--consectetur--adipisicing">consectetur &#x26; adipisicing</h3>',
+            '  <h4 id="prefix--elit">elit</h4>',
+            '  <h5 id="prefix--elit-1">Elit</h5>',
+            '  <h5 id="prefix--elit-">Elit </h5>',
+            '  <p>sed</p>',
+            '</section>'
+          ].join('\n'),
+          'should match'
+        )
+      }
+    )
+
+  rehype()
+    .data('settings', {fragment: true})
+    .use(rehypeSlug, {
+      slugger: {slug: (_value) => `test--${_value}--test`}
+    })
+    .process(
+      [
+        '<section>',
+        '  <h1>Lorem ipsum 😪</h1>',
+        '  <h2>dolor—sit—amet</h2>',
+        '  <h3>consectetur &amp; adipisicing</h3>',
+        '  <h4>elit</h4>',
+        '  <h5>Elit</h5>',
+        '  <h5>Elit </h5>',
+        '  <p>sed</p>',
+        '</section>'
+      ].join('\n'),
+      (error, file) => {
+        t.ifErr(error, 'shouldn’t throw')
+
+        t.equal(
+          String(file),
+          [
+            '<section>',
+            '  <h1 id="test--Lorem ipsum 😪--test">Lorem ipsum 😪</h1>',
+            '  <h2 id="test--dolor—sit—amet--test">dolor—sit—amet</h2>',
+            '  <h3 id="test--consectetur &#x26; adipisicing--test">consectetur &#x26; adipisicing</h3>',
+            '  <h4 id="test--elit--test">elit</h4>',
+            '  <h5 id="test--Elit--test">Elit</h5>',
+            '  <h5 id="test--Elit --test">Elit </h5>',
+            '  <p>sed</p>',
+            '</section>'
+          ].join('\n'),
+          'should match'
+        )
+      }
+    )
+
+  rehype()
+    .data('settings', {fragment: true})
+    .use(rehypeSlug, {
+      prefix: 'prefix--',
+      slugger: {
+        slug: (_value) =>
+          `test--${_value.replace(/\W/g, '').toLowerCase()}--test`
+      }
+    })
+    .process(
+      [
+        '<section>',
+        '  <h1>Lorem ipsum 😪</h1>',
+        '  <h2>dolor—sit—amet</h2>',
+        '  <h3>consectetur &amp; adipisicing</h3>',
+        '  <h4>elit</h4>',
+        '  <h5>Elit</h5>',
+        '  <h5>Elit </h5>',
+        '  <p>sed</p>',
+        '</section>'
+      ].join('\n'),
+      (error, file) => {
+        t.ifErr(error, 'shouldn’t throw')
+
+        t.equal(
+          String(file),
+          [
+            '<section>',
+            '  <h1 id="prefix--test--loremipsum--test">Lorem ipsum 😪</h1>',
+            '  <h2 id="prefix--test--dolorsitamet--test">dolor—sit—amet</h2>',
+            '  <h3 id="prefix--test--consecteturadipisicing--test">consectetur &#x26; adipisicing</h3>',
+            '  <h4 id="prefix--test--elit--test">elit</h4>',
+            '  <h5 id="prefix--test--elit--test">Elit</h5>',
+            '  <h5 id="prefix--test--elit--test">Elit </h5>',
+            '  <p>sed</p>',
+            '</section>'
+          ].join('\n'),
+          'should match'
+        )
+      }
+    )
+
+  rehype()
+    .data('settings', {fragment: true})
+    .use(rehypeSlug, {
+      prefix: 'prefix--',
+      slugger: {
+        slug: (_value) =>
+          slugify(_value, {lower: true, strict: true, replacement: '__'})
+      }
+    })
+    .process(
+      [
+        '<section>',
+        '  <h1>Lorem ipsum 😪</h1>',
+        '  <h2>dolor—sit—amet</h2>',
+        '  <h3>consectetur &amp; adipisicing</h3>',
+        '  <h4>elit</h4>',
+        '  <h5>Elit</h5>',
+        '  <h5>Elit </h5>',
+        '  <p>sed</p>',
+        '</section>'
+      ].join('\n'),
+      (error, file) => {
+        t.ifErr(error, 'shouldn’t throw')
+
+        t.equal(
+          String(file),
+          [
+            '<section>',
+            '  <h1 id="prefix--lorem__ipsum">Lorem ipsum 😪</h1>',
+            '  <h2 id="prefix--dolorsitamet">dolor—sit—amet</h2>',
+            '  <h3 id="prefix--consectetur__and__adipisicing">consectetur &#x26; adipisicing</h3>',
+            '  <h4 id="prefix--elit">elit</h4>',
+            '  <h5 id="prefix--elit">Elit</h5>',
+            '  <h5 id="prefix--elit">Elit </h5>',
             '  <p>sed</p>',
             '</section>'
           ].join('\n'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["*.js"],
+  "exclude": ["test.js"],
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

This adds new support for an additonal `option` containing a custom `slugger` implementation. By default it still uses the "built in" (opinionated) `github-slugger` but also supports your own customer `slugger`:

This could be another popular third party package such as `slugify` and/or your own custom implementation.

Ex usage (custom slugger):
```
  rehype()
    .data('settings', {fragment: true})
    .use(rehypeSlug, {
      slugger: {
        slug: (_value) =>
          `test--${_value.replace(/\W/g, '').toLowerCase()}--test`
      }
    })
```

Ex usage (making uses of `slugify`):
```
  rehype()
    .data('settings', {fragment: true})
    .use(rehypeSlug, {
      prefix: 'prefix--',
      slugger: {
        slug: slugify,
        // Can be used with custom options such as:
        // slug: (_value) => slugify(_value, {lower: true, strict: true, replacement: '__'})
      }
    })
```

Related to #16
Closes #17

<!--do not edit: pr-->